### PR TITLE
fix: update CLI prompt formatting in tap.py

### DIFF
--- a/tapflow/cli/tap.py
+++ b/tapflow/cli/tap.py
@@ -22,10 +22,10 @@ from IPython.terminal.prompts import Prompts, Token
 
 class NoPrompt(Prompts):
     def in_prompt_tokens(self, cli=None):
-        return [(Token.Prompt, 'tap > ')]
+        return [(Token.Prompt, 'tap> ')]
 
     def out_prompt_tokens(self):
-        return [(Token.OutPrompt, 'tap > ')]
+        return [(Token.OutPrompt, 'tap> ')]
 
 c.TerminalInteractiveShell.prompts_class = NoPrompt
 ''')


### PR DESCRIPTION
- Changed the prompt format in the NoPrompt class from 'tap > ' to 'tap> ' for a cleaner appearance.
- Adjusted both input and output prompt tokens to maintain consistency in the CLI interface.