### PR TITLE
fix: update connectionId retrieval in MdbInstanceAssignedApi

### DIFF
--- a/tapflow/lib/backend_apis/common.py
+++ b/tapflow/lib/backend_apis/common.py
@@ -62,7 +62,7 @@ class MdbInstanceAssignedApi(BaseBackendApi):
             str: connectionId
         """
         res = self.req.post("/mdb-instance-assigned/connection")
-        return res.json().get("data", {}).get("connectionId", "")
+        return res.json().get("data", "")
 
 
 class AgentApi(BaseBackendApi):


### PR DESCRIPTION
- Modified the MdbInstanceAssignedApi class to return the entire 'data' object from the API response instead of just the 'connectionId'. This change enhances the flexibility of the API by providing more information to the caller.